### PR TITLE
k8s.service_accounts depends on iam_member.main

### DIFF
--- a/workload-identity.tf
+++ b/workload-identity.tf
@@ -8,7 +8,8 @@ locals {
 
 resource "kubernetes_service_account" "service_accounts" {
   depends_on = [
-    kubernetes_namespace.namespaces
+    kubernetes_namespace.namespaces,
+    google_service_account_iam_member.main
   ]
   for_each                        = local.workload_identity_profiles
   automount_service_account_token = true


### PR DESCRIPTION
Updates `depends_on` to account for `kubernetes_service_account. service_accounts ` depends on `google_service_account_iam_member.main` in order to complete successfully.  Since `workload_identity_profiles` are typically string interpolated arrays, this dependency is necessary.