### PR TITLE
Add annotations and labels for sidecar injection in ASM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,14 @@ locals {
     ? var.project_id
     : var.peering_config.project_id
   )
+
+  namespace_protection_annotations = var.namespace_protection ? { "protected" = "yes" } : {}
+  sidecar_injection_annotations    = var.sidecar_injection ? { "mesh.cloud.google.com/proxy" = "{ \"managed\" : \"true\"}" } : {}
+
+  all_namespace_annotations = merge(local.namespace_protection_annotations,
+  local.sidecar_injection_annotations)
+
+  k8s_namespace_labels = var.sidecar_injection ? { "istio.io/rev" = "asm-managed" } : {}
 }
 
 resource "google_container_cluster" "cluster" {
@@ -245,7 +253,9 @@ resource "kubernetes_namespace" "namespaces" {
   for_each = toset(var.namespaces)
   metadata {
     name        = each.value
-    annotations = var.namespace_protection ? { "protected" = "yes" } : {}
+    annotations = local.all_namespace_annotations
+
+    labels = local.k8s_namespace_labels
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -293,3 +293,9 @@ variable "create_cpr" {
   type        = bool
   default     = false
 }
+
+variable "sidecar_injection" {
+  description = "If true - mark namespace with annotation so sidecar proxies can be injected"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
After enabling Anthos Service Mesh for it to take effect fully there is need to label the namespaces concerned so that the sidecar proxies can be injected.