### PR TITLE
Include automount_service_account_token variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -293,3 +293,9 @@ variable "create_cpr" {
   type        = bool
   default     = false
 }
+
+variable "automount_service_account_token" {
+  description = "Instructs the cluster whether or not to automatically mount a kubernetes service account token.  Past GKE 1.24, tokens are not automatically created for a service account"
+  type        = bool
+  default     = true # done for backward compatibility
+}

--- a/workload-identity.tf
+++ b/workload-identity.tf
@@ -15,7 +15,7 @@ resource "kubernetes_service_account" "service_accounts" {
     kubernetes_namespace.namespaces
   ]
   for_each                        = local.workload_identity_profiles
-  automount_service_account_token = true
+  automount_service_account_token = var.automount_service_account_token
   metadata {
     name      = element(split("@", each.value.gsa), 0)
     namespace = each.value.namespace


### PR DESCRIPTION
Prior to GKE 1.24, a token was created for every kubernetes service account, and was automatically mounted for used to authenticate requests from in-cluster processes to the GKE API server.  This approach is problematic and doesn't follow a least privilege approach, as many k8s service accounts don't actually require this level of access.  This creates a `automount_service_account_token` variable to allow this to be set to false.  For backward compatibility, this variable is set to `true` by default.