### PR TITLE
Replace kubernetes_service_account resource

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -264,10 +264,19 @@ variable "enable_autopilot" {
 
 variable "workload_identity_profiles" {
   description = <<EOF
-  Namespace-keyed map of GCP Service Account emails to create K8S Service Accounts for.
+  Namespace-keyed map of GCP Service Account to create K8S Service Accounts for.
   EOF
-  type        = map(list(string))
-  default     = {}
+  type = map(
+    list(
+      object(
+        {
+          email                           = string
+          automount_service_account_token = optional(bool, true)
+        }
+      )
+    )
+  )
+  default = {}
 }
 
 variable "namespaces" {
@@ -292,10 +301,4 @@ variable "create_cpr" {
   description = "Determines if the control plane revision should be installed"
   type        = bool
   default     = false
-}
-
-variable "automount_service_account_token" {
-  description = "Instructs the cluster whether or not to automatically mount a kubernetes service account token.  Past GKE 1.24, tokens are not automatically created for a service account"
-  type        = bool
-  default     = true # done for backward compatibility
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3.8"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
The kubernetes provider still depends on the automatic creation of a service account token in order to successfully create a service account.
Until that's sorted we'll create service accounts with using the raw manifest resource, create a service account token and link it to the service account for full backwards compatibility.
K8S recommends getting service account tokens using a [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) and we'll update the module to reflect that in the near future