### PR TITLE
Set provider constraint and revert to resource

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -271,7 +271,7 @@ variable "workload_identity_profiles" {
       object(
         {
           email                           = string
-          automount_service_account_token = optional(bool, true)
+          automount_service_account_token = optional(bool, false)
         }
       )
     )

--- a/versions.tf
+++ b/versions.tf
@@ -25,5 +25,9 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 4.0.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.19"
+    }
   }
 }

--- a/workload-identity.tf
+++ b/workload-identity.tf
@@ -14,7 +14,7 @@ locals {
 
 # Service account tokens
 resource "kubernetes_secret_v1" "tokens" {
-  for_each = local.workload_identity_profiles
+  for_each = { for k, v in local.workload_identity_profiles : k => v if v.automount_service_account_token }
 
   metadata {
     name = "${each.value.name}-service-account-token"
@@ -27,35 +27,29 @@ resource "kubernetes_secret_v1" "tokens" {
   type = "kubernetes.io/service-account-token"
 }
 
-resource "kubernetes_manifest" "service_accounts" {
+resource "kubernetes_service_account" "service_accounts" {
   depends_on = [
     kubernetes_namespace.namespaces,
     kubernetes_secret_v1.tokens,
   ]
   for_each = local.workload_identity_profiles
 
-  manifest = {
-    apiVersion                   = "v1"
-    kind                         = "ServiceAccount"
-    automountServiceAccountToken = each.value.automount_service_account_token
-    secrets = [{
-      name = "${each.value.name}-service-account-token"
-    }]
-    metadata = {
-      name      = each.value.name
-      namespace = each.value.namespace
-      annotations = {
-        "iam.gke.io/gcp-service-account" = each.value.email
-      }
+  metadata {
+    name      = each.value.name
+    namespace = each.value.namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = each.value.email
     }
   }
+
+  automount_service_account_token = each.value.automount_service_account_token
 }
 
 # Allow the KSA to impersonate the GSA by creating IAM policy binding between them
 resource "google_service_account_iam_member" "main" {
   for_each = local.workload_identity_profiles
   depends_on = [
-    kubernetes_manifest.service_accounts
+    kubernetes_service_account.service_accounts
   ]
   # service account id references service account project
   service_account_id = "projects/${each.value.project_id}/serviceAccounts/${each.value.email}"


### PR DESCRIPTION
Only create service account token secrets for service accounts configured to auto-mount tokens.
Update k8s provider version constraint