### PR TITLE
Fix workload identity service account token error

### DIFF
--- a/workload-identity.tf
+++ b/workload-identity.tf
@@ -14,6 +14,9 @@ locals {
 
 # Service account tokens
 resource "kubernetes_secret_v1" "tokens" {
+  depends_on = [
+    kubernetes_service_account.service_accounts
+  ]
   for_each = { for k, v in local.workload_identity_profiles : k => v if v.automount_service_account_token }
 
   metadata {
@@ -30,7 +33,6 @@ resource "kubernetes_secret_v1" "tokens" {
 resource "kubernetes_service_account" "service_accounts" {
   depends_on = [
     kubernetes_namespace.namespaces,
-    kubernetes_secret_v1.tokens,
   ]
   for_each = local.workload_identity_profiles
 


### PR DESCRIPTION
The service account needs to be created before the service account token. I blame Marcelo.

As the code is currently, it errors if you set [automount_service_account_token to true](https://github.com/dapperlabs-platform/terraform-google-gke-cluster/blob/main/variables.tf#L263) for a workload-identity profile. So this change fixes that particular situation.

Ref: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1943#issuecomment-1369546028