### PR TITLE
Adding filestore support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,9 @@ resource "google_container_cluster" "cluster" {
     gce_persistent_disk_csi_driver_config {
       enabled = var.addons.gce_persistent_disk_csi_driver_config
     }
+    gcp_filestore_csi_driver_config {
+      enabled = var.addons.gcp_filestore_csi_driver_config.enabled
+    }
   }
 
   # TODO(ludomagno): support setting address ranges instead of range names
@@ -263,4 +266,18 @@ module "enable_asm" {
   create_cpr                = var.create_cpr
 
   depends_on = [google_container_cluster.cluster]
+}
+
+// If enabling filestore, creates a storage class that can be used in the cluster
+resource "kubernetes_storage_class" "example" {
+  count = var.addons.gcp_filestore_csi_driver_config.enabled ? 1 : 0
+
+  metadata {
+    name = "filestore"
+  }
+  storage_provisioner = "filestore.csi.storage.gke.io"
+  parameters = {
+    tier    = var.addons.gcp_filestore_csi_driver_config.tier
+    network = var.network
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,10 @@ variable "addons" {
     }), {})
     network_policy_config                 = optional(bool, true)
     gce_persistent_disk_csi_driver_config = optional(bool, true)
+    gcp_filestore_csi_driver_config = optional(object({
+      enabled = optional(bool, false)
+      tier    = optional(string, "standard")
+    }), {})
   })
   default = {}
 }


### PR DESCRIPTION
Adds support to use GCP filestore. This is useful for applications that need a pvc with ReadWriteMany access mode (i.e. several nodes need the ability to write data to it). 

This is initially being enabled to test support with our self-hosted Retool deployment which needs ReadWriteMany permissions to be able to scale the main deployment while persisting data.

tested in this pr: https://github.com/dapperlabs/eng-ops-infrastructure/pull/19