### PR TITLE
Fixing small error with filestore network

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -278,6 +278,6 @@ resource "kubernetes_storage_class" "example" {
   storage_provisioner = "filestore.csi.storage.gke.io"
   parameters = {
     tier    = var.addons.gcp_filestore_csi_driver_config.tier
-    network = var.network
+    network = "gke-application-cluster-vpc"
   }
 }


### PR DESCRIPTION
We need to use the short name for the network parameter or the PVC doesn't work. Whoops.