### PR TITLE
Remove deprecated field

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ No modules.
 | <a name="input_default_max_pods_per_node"></a> [default\_max\_pods\_per\_node](#input\_default\_max\_pods\_per\_node) | Maximum number of pods per node in this cluster. | `number` | `110` | no |
 | <a name="input_description"></a> [description](#input\_description) | Cluster description. | `string` | `null` | no |
 | <a name="input_enable_autopilot"></a> [enable\_autopilot](#input\_enable\_autopilot) | Create cluster in autopilot mode. With autopilot there's no need to create node-pools and some features are not supported (e.g. setting default\_max\_pods\_per\_node) | `bool` | `false` | no |
-| <a name="input_enable_binary_authorization"></a> [enable\_binary\_authorization](#input\_enable\_binary\_authorization) | Enable Google Binary Authorization. | `bool` | `null` | no |
 | <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | Enable Dataplane V2 on the cluster, will disable network\_policy addons config | `bool` | `false` | no |
 | <a name="input_enable_intranode_visibility"></a> [enable\_intranode\_visibility](#input\_enable\_intranode\_visibility) | Enable intra-node visibility to make same node pod to pod traffic visible. | `bool` | `null` | no |
 | <a name="input_enable_shielded_nodes"></a> [enable\_shielded\_nodes](#input\_enable\_shielded\_nodes) | Enable Shielded Nodes features on all nodes in this cluster. | `bool` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ resource "google_container_cluster" "cluster" {
   monitoring_service          = var.monitoring_service
   resource_labels             = var.labels
   default_max_pods_per_node   = var.enable_autopilot ? null : var.default_max_pods_per_node
-  enable_binary_authorization = var.enable_binary_authorization
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_shielded_nodes       = var.enable_shielded_nodes
   enable_tpu                  = var.enable_tpu

--- a/variables.tf
+++ b/variables.tf
@@ -91,12 +91,6 @@ variable "description" {
   default     = null
 }
 
-variable "enable_binary_authorization" {
-  description = "Enable Google Binary Authorization."
-  type        = bool
-  default     = null
-}
-
 variable "enable_intranode_visibility" {
   description = "Enable intra-node visibility to make same node pod to pod traffic visible."
   type        = bool


### PR DESCRIPTION
binary auth has been deprecated in 5.0, so let's remove it.