### PR TITLE
Adding goldilocks namespace label

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,9 @@ resource "kubernetes_namespace" "namespaces" {
   metadata {
     name        = each.value
     annotations = var.namespace_protection ? { "protected" = "yes" } : {}
+    labels = {
+      "goldilocks.fairwinds.com/enabled" = "true"
+    }
   }
 }
 


### PR DESCRIPTION
Adds goldilocks label to namespaces defined in Terraform. This helps Terraform not delete these labels in any environment where we deploy [Goldilocks](https://goldilocks.docs.fairwinds.com/#how-can-this-help-with-my-resource-settings).