### PR TITLE
Disables deletion-protection for multi-region clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ resource "google_container_cluster" "cluster" {
   remove_default_node_pool    = var.enable_autopilot ? null : true
   datapath_provider           = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "DATAPATH_PROVIDER_UNSPECIFIED"
   enable_autopilot            = var.enable_autopilot == true ? true : null
+  deletion_protection         = var.secondary_region == true ? false : true
 
   # node_config {}
   # NOTE: Default node_pool is deleted, so node_config (here) is extranneous.


### PR DESCRIPTION
In order to more quickly scale up and down extra regions we want the secondary clusters (marked as secondary_region variable) to not have deletion_protection on (it is technically on by default). This will allow us to delete regions via a Terraform apply action, as otherwise we would need to manually delete the cluster. This change makes it so it only applies to multi-region clusters, and never the base cluster.